### PR TITLE
Styled up the preview window

### DIFF
--- a/previewImagesFromSidebar/assets/css/preview-on-hover.css
+++ b/previewImagesFromSidebar/assets/css/preview-on-hover.css
@@ -1,12 +1,37 @@
+.fileuploadpreview:hover::before{
+  position: absolute;
+  content: "▲";
+  color: #fff;
+  z-index: 10;
+  display: block;
+  width: 50px;
+  height: 60px;
+  margin-left: 1em;
+  text-shadow: 0 2px 10px rgba(0,0,0, .6);
+  -ms-transform:     scale(2.8, 1.5) translate(12px, 15px); /* IE 9 */
+  -moz-transform:    scale(2.8, 1.5) translate(12px, 15px);
+  -webkit-transform: scale(2.8, 1.5) translate(12px, 15px);
+  transform:         scale(2.8, 1.5) translate(12px, 15px);
+}
+
 .fileuploadpreview::after {
   content: '';
   display: none;
   width: 10em;
+  background-color: #fff;
   background-size: contain;
-  height: 6em;
+  background-position: center;
+  height: 10em;
   background-repeat: no-repeat;
   position: fixed;
   z-index: 2;
+  pointer-events: none;
+  border: 10px solid #fff;
+  box-shadow: rgba(0,0,0, .2) 0px 2px 10px;
+  -ms-transform:     translate(0px, 4px); /* IE 9 */
+  -moz-transform:    translate(0px, 4px);
+  -webkit-transform: translate(0px, 4px);
+  transform:         translate(0px, 4px);
 }
 
 .fileuploadpreview:hover::after {


### PR DESCRIPTION
CSS pointer-events: none; allows you to hover over the whole list without the image previews getting in the way.

The drop down style is based on existing panel UI: http://ui.getkirby.com/panel/atoms/navigation

Unfortunately, there doesn't seem to be a way to add box shadows to triangles created with pure css.
